### PR TITLE
Modernize action to action call to resolve default values

### DIFF
--- a/fastlane/lib/fastlane/actions/build_and_upload_to_appetize.rb
+++ b/fastlane/lib/fastlane/actions/build_and_upload_to_appetize.rb
@@ -18,7 +18,7 @@ module Fastlane
         zipped_bundle = Actions::ZipAction.run(path: app_path,
                                         output_path: File.join(tmp_path, "Result.zip"))
 
-        Actions::AppetizeAction.run(path: zipped_bundle,
+        other_action.appetize(path: zipped_bundle,
                                api_token: params[:api_token])
 
         public_key = Actions.lane_context[SharedValues::APPETIZE_PUBLIC_KEY]


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines]
- [x] I've updated the documentation if necessary.

### Description
Modernize the Action to Action call to fix action default parameters.   Without the change `AppetizeAction` is called without evaluating of the `available_options`.   

Updating to the new newer syntax of `other_action.appetize(path: zipped_bundle, ...` resolves these problems.

### Motivation and Context

When `BuildAndUploadToAppetizeAction` invokes `AppetizeAction`, it loses the context of the calling lane, as well as bypasses the default mappings of `AppetizeAction::available_options`.  

As such, there is no method to asset `APPETIZE_PUBLICKEY`, or `APPETIZE_NOTE` to the underlying `AppetizeAction`'s implementation.

For an iOS build, it can be observed that calling the `BuildAndUploadToAppetizeAction`, that a console message will be emitted by `AppetizeAction` indicating that an APK is being uploaded, even if the target platform is iOS.   This is caused by the available_options not setting the default_platform setting.

[relates to #4441](https://github.com/fastlane/fastlane/pull/4441)
